### PR TITLE
add "data structure" keyword in description

### DIFF
--- a/cl-digraph.asd
+++ b/cl-digraph.asd
@@ -1,5 +1,5 @@
 (asdf:defsystem :cl-digraph
-  :description "Simple directed graphs for Common Lisp."
+  :description "Simple directed graphs data structure for Common Lisp."
 
   :author "Steve Losh <steve@stevelosh.com>"
 


### PR DESCRIPTION
Hello !

That's really my 0.02 cents but I'd like Quicklisp libraries to be better organized, thus easier to find, so if we add this keyword we could see cl-digraph in a Quickdocs search:  http://quickdocs.org/search?q=data+structure

and I considered it was a quicker fix to add this than to tweak Quickdocs, ASDF and I don't know what :)

Cheers !