### PR TITLE
Stop passing NIL as :hash-function during hash table construction

### DIFF
--- a/src/directed-graph.lisp
+++ b/src/directed-graph.lisp
@@ -2,12 +2,13 @@
 
 ;;;; Utils --------------------------------------------------------------------
 (defun make-hash-table-portably (&key (size 0) test hash-function)
-  (make-hash-table
+  (apply #'make-hash-table
     :test test
     :size size
     ;; Don't explode if the implementation doesn't support :hash-function.
     :allow-other-keys t
-    :hash-function hash-function))
+    (when hash-function
+      (list :hash-function hash-function))))
 
 
 ;;;; Data ---------------------------------------------------------------------


### PR DESCRIPTION
At least in SBCL 2.0.6, passing :hash-function NIL to make-hash-table causes an
UNDEFINED-FUNCTION error. Since it's unlikely that any other CL implementation
will have useful behavior for an explicit NIL argument that's different from not
passing it at all, it's better to not pass :hash-function if it's set to NIL.